### PR TITLE
Add MemoryPath.remove along with all the stuff that'd need to come with it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 _trial_temp
+version.txt

--- a/bp/abstract.py
+++ b/bp/abstract.py
@@ -146,7 +146,7 @@ class IFilePath(Interface):
         children before removing the directory. If it's a file or link,
         just delete it.
 
-        @raise Exception: If the file or directory does not already exist
+        @raise PathError: If the file or directory does not already exist
         """
 
     # Stat and other queries

--- a/bp/abstract.py
+++ b/bp/abstract.py
@@ -138,6 +138,17 @@ class IFilePath(Interface):
         @type ext: L{bytes}
         """
 
+    def remove():
+        """
+        Remove the file or directory at this path.
+
+        If C{self.path} is a directory, recursively remove all its
+        children before removing the directory. If it's a file or link,
+        just delete it.
+
+        @raise Exception: If the file or directory does not already exist
+        """
+
     # Stat and other queries
 
     def changed():

--- a/bp/abstract.py
+++ b/bp/abstract.py
@@ -19,7 +19,7 @@ class IFilePath(Interface):
     File path object.
 
     A file path represents a location for a file-like-object and can be
-    organized into a hierarchy; a file path can can children which are
+    organized into a hierarchy; a file path can have children which are
     themselves file paths.
 
     A file path has a name which uniquely identifies it in the context of its

--- a/bp/errors.py
+++ b/bp/errors.py
@@ -23,3 +23,6 @@ class UnlistableError(Exception):
     An exception which is used to distinguish between errors which mean 'this
     is not a directory you can list' and other, more catastrophic errors.
     """
+
+
+PathError = IOError

--- a/bp/filepath.py
+++ b/bp/filepath.py
@@ -227,7 +227,7 @@ class FilePath(object):
     statinfo = None
     path = None
 
-    sep = slash.encode("ascii")
+    sep = slash
 
     children = genericChildren
     descendant = genericDescendant

--- a/bp/iso.py
+++ b/bp/iso.py
@@ -20,7 +20,7 @@ from struct import unpack
 from zope.interface import implementer
 
 from bp.abstract import IFilePath
-from bp.errors import UnlistableError
+from bp.errors import PathError, UnlistableError
 from bp.generic import (genericChildren, genericParents, genericSegmentsFrom,
                         genericSibling, genericWalk)
 from bp.util import modeIsWriting
@@ -297,7 +297,7 @@ class ISOPath(object):
         raise Exception("ISOs are read-only")
 
     def remove(self):
-        raise Exception("ISOs are read-only")
+        raise PathError("ISOs are read-only")
 
     # IFilePath stat and other queries
 

--- a/bp/iso.py
+++ b/bp/iso.py
@@ -296,6 +296,9 @@ class ISOPath(object):
     def setContent(self, content, ext=b".new"):
         raise Exception("ISOs are read-only")
 
+    def remove(self):
+        raise Exception("ISOs are read-only")
+
     # IFilePath stat and other queries
 
     def changed(self):

--- a/bp/iso.py
+++ b/bp/iso.py
@@ -14,7 +14,7 @@
 from calendar import timegm
 from collections import namedtuple
 from datetime import datetime
-from StringIO import StringIO
+from io import StringIO
 from struct import unpack
 
 from zope.interface import implementer

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -213,3 +213,6 @@ class MemoryPath(object):
 
     def realpath(self):
         return self
+
+    def dirname(self):
+        return self.parent().path

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -11,6 +11,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from errno import ENOENT
 from itertools import chain
 from StringIO import StringIO
 
@@ -157,7 +158,7 @@ class MemoryPath(object):
             try:
                 del self._fs._store[self._path]
             except KeyError:
-                raise PathError(self._path)
+                raise PathError(ENOENT, self._path)
 
     # IFilePath stat and other queries
 

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -150,6 +150,8 @@ class MemoryPath(object):
 
     def remove(self):
         if self.isdir():
+            for child in self.children():
+                child.remove()
             self._fs._dirs.remove(self._path)
         else:
             del self._fs._store[self._path]

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -17,8 +17,8 @@ from itertools import chain
 import os
 import stat
 
-from characteristic import Attribute, attributes, with_repr
 from zope.interface import implementer
+import attr
 
 from bp.abstract import IFilePath
 from bp.errors import PathError, UnlistableError
@@ -90,17 +90,15 @@ def format_memory_path(path, sep):
 
 
 @implementer(IFilePath)
-@attributes(
-    [
-        Attribute(name="_fs", exclude_from_repr=True),
-        Attribute(name="_path", default_value=(), exclude_from_repr=True),
-        Attribute(name="path", exclude_from_init=True),
-    ],
-)
+@attr.s(hash=True)
 class MemoryPath(object):
     """
     An IFilePath which shows a view into a MemoryFS.
     """
+
+    _fs = attr.ib(repr=False)
+    _path = attr.ib(default=(), repr=False)
+    path = attr.ib(init=False)
 
     sep = "/"
 

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -164,6 +164,8 @@ class MemoryPath(object):
             raise PathError(ENOENT, self._path)
 
     def setContent(self, content, ext=b".new"):
+        if not self.parent().exists():
+            raise PathError(ENOENT, self._path)
         self._fs._store[self._path] = content
 
     def remove(self):

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 from errno import EEXIST, ENOENT
-from io import StringIO
+from io import BytesIO
 from itertools import chain
 import os
 import stat
@@ -29,13 +29,13 @@ DIR = object()
 FILE = object()
 
 
-class MemoryFile(StringIO):
+class MemoryFile(BytesIO):
     """
     A file-like object that saves itself to an external mapping when closed.
     """
 
     def __init__(self, store, key, buf=""):
-        StringIO.__init__(self, buf)
+        BytesIO.__init__(self, buf)
         self._target = store, key
 
     def __enter__(self):
@@ -48,7 +48,7 @@ class MemoryFile(StringIO):
         buf = self.getvalue()
         store, key = self._target
         store[key] = buf
-        StringIO.close(self)
+        BytesIO.close(self)
 
 
 class MemoryFS(object):

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -148,6 +148,12 @@ class MemoryPath(object):
     def setContent(self, content, ext=b".new"):
         self._fs._store[self._path] = content
 
+    def remove(self):
+        if self.isdir():
+            self._fs._dirs.remove(self._path)
+        else:
+            del self._fs._store[self._path]
+
     # IFilePath stat and other queries
 
     def changed(self):

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -74,7 +74,7 @@ def format_memory_path(path, sep):
 @implementer(IFilePath)
 @attributes(
     [
-        Attribute(name="_fs"),
+        Attribute(name="_fs", exclude_from_repr=True),
         Attribute(name="_path", default_value=(), exclude_from_repr=True),
         Attribute(name="path", exclude_from_init=True),
     ],

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -152,7 +152,10 @@ class MemoryPath(object):
         self._fs._dirs.add(self._path)
 
     def getContent(self):
-        return self._fs._store[self._path]
+        try:
+            return self._fs._store[self._path]
+        except KeyError:
+            raise PathError(ENOENT, self._path)
 
     def setContent(self, content, ext=b".new"):
         self._fs._store[self._path] = content

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -15,6 +15,7 @@ from errno import ENOENT
 from itertools import chain
 from StringIO import StringIO
 
+from characteristic import Attribute, attributes, with_repr
 from zope.interface import implementer
 
 from bp.abstract import IFilePath
@@ -71,26 +72,19 @@ def format_memory_path(path, sep):
 
 
 @implementer(IFilePath)
+@attributes(
+    [
+        Attribute(name="_fs"),
+        Attribute(name="_path", default_value=(), exclude_from_repr=True),
+        Attribute(name="path", exclude_from_init=True),
+    ],
+)
 class MemoryPath(object):
     """
     An IFilePath which shows a view into a MemoryFS.
     """
 
     sep = "/"
-
-    def __init__(self, fs, path=()):
-        """
-        Create a new path in memory.
-        """
-
-        self._fs = fs
-        self._path = path
-
-    def __eq__(self, other):
-        return self._fs == other._fs and self._path == other._path
-
-    def __hash__(self):
-        return hash((MemoryPath, self._fs, self._path))
 
     @property
     def path(self):
@@ -125,15 +119,15 @@ class MemoryPath(object):
 
     def parent(self):
         if self._path:
-            return MemoryPath(self._fs, self._path[:-1])
+            return MemoryPath(fs=self._fs, path=self._path[:-1])
         else:
             return self
 
     def child(self, name):
-        return MemoryPath(self._fs, self._path + (name,))
+        return MemoryPath(fs=self._fs, path=self._path + (name,))
 
     def descendant(self, segments):
-        return MemoryPath(self._fs, self._path + tuple(segments))
+        return MemoryPath(fs=self._fs, path=self._path + tuple(segments))
 
     # IFilePath writing and reading
 

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -60,6 +60,7 @@ class MemoryFS(object):
         self._store = {}
         self._dirs = set()
         self._uids = {}
+        self._links = {}
 
     def open(self, path):
         if path in self._dirs:
@@ -183,7 +184,7 @@ class MemoryPath(object):
         return self._path in self._fs._store
 
     def islink(self):
-        return False
+        return self in self._fs._links
 
     def exists(self):
         return self.isdir() or self.isfile()
@@ -212,7 +213,10 @@ class MemoryPath(object):
     # IFilePath symlinks
 
     def realpath(self):
-        return self
+        return self._fs._links.get(self, self).path
 
     def dirname(self):
         return self.parent().path
+
+    def linkTo(self, linkFilePath):
+        self._fs._links[linkFilePath] = self

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -97,8 +97,7 @@ class MemoryPath(object):
     """
 
     _fs = attr.ib(repr=False)
-    _path = attr.ib(default=(), repr=False)
-    path = attr.ib(init=False)
+    _path = attr.ib(default=())
 
     sep = "/"
 

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -110,7 +110,7 @@ class MemoryPath(object):
         if self._path not in self._fs._dirs:
             raise UnlistableError()
 
-        i = chain(self._fs._dirs, self._fs._store.iterkeys())
+        i = chain(self._fs._dirs, self._fs._store.keys())
 
         # Linear-time search. Could be better.
         p = self._path

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -17,7 +17,7 @@ from StringIO import StringIO
 from zope.interface import implementer
 
 from bp.abstract import IFilePath
-from bp.errors import UnlistableError
+from bp.errors import PathError, UnlistableError
 from bp.generic import (genericChildren, genericParents, genericSegmentsFrom,
                         genericSibling, genericWalk)
 
@@ -154,7 +154,10 @@ class MemoryPath(object):
                 child.remove()
             self._fs._dirs.remove(self._path)
         else:
-            del self._fs._store[self._path]
+            try:
+                del self._fs._store[self._path]
+            except KeyError:
+                raise PathError(self._path)
 
     # IFilePath stat and other queries
 

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 from errno import EEXIST, ENOENT
+from io import StringIO
 from itertools import chain
-from StringIO import StringIO
 import os
 import stat
 

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -62,6 +62,11 @@ class MemoryFS(object):
         self._uids = {}
         self._links = {}
 
+    def create(self, path):
+        if path in self._dirs or path in self._store:
+            raise PathError("{0} already exists.".format(path))
+        return MemoryFile(self._store, path)
+
     def open(self, path):
         if path in self._dirs:
             raise Exception("Directories cannot be opened")
@@ -143,6 +148,9 @@ class MemoryPath(object):
         return MemoryPath(fs=self._fs, path=self._path + tuple(segments))
 
     # IFilePath writing and reading
+
+    def create(self):
+        return self._fs.create(self._path)
 
     def open(self, mode="r"):
         return self._fs.open(self._path)

--- a/bp/memory.py
+++ b/bp/memory.py
@@ -11,7 +11,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from errno import ENOENT
+from errno import EEXIST, ENOENT
 from itertools import chain
 from StringIO import StringIO
 
@@ -135,6 +135,8 @@ class MemoryPath(object):
         return self._fs.open(self._path)
 
     def createDirectory(self):
+        if self._path in self._fs._store:
+            raise PathError(EEXIST, self._path)
         self._fs._dirs.add(self._path)
 
     def getContent(self):

--- a/bp/readonly.py
+++ b/bp/readonly.py
@@ -14,6 +14,7 @@
 from zope.interface import implementer
 
 from bp.abstract import IFilePath
+from bp.errors import PathError
 from bp.generic import (genericChildren, genericDescendant, genericParents,
                         genericSegmentsFrom, genericSibling, genericWalk)
 from bp.util import modeIsWriting
@@ -84,7 +85,7 @@ class ReadOnlyPath(object):
         raise Exception("Path is read-only")
 
     def remove(self):
-        raise Exception("Path is read-only")
+        raise PathError("Path is read-only")
 
     # IFilePath stat and other queries
 

--- a/bp/readonly.py
+++ b/bp/readonly.py
@@ -83,6 +83,9 @@ class ReadOnlyPath(object):
     def setContent(self, content, ext=b'.new'):
         raise Exception("Path is read-only")
 
+    def remove(self):
+        raise Exception("Path is read-only")
+
     # IFilePath stat and other queries
 
     def changed(self):

--- a/bp/tests/test_iso.py
+++ b/bp/tests/test_iso.py
@@ -48,7 +48,7 @@ class ISOPathTestCase(AbstractFilePathTestCase):
 
     def setUp(self):
         fs = MemoryFS()
-        fp = MemoryPath(fs).child("test.iso")
+        fp = MemoryPath(fs=fs).child("test.iso")
         fp.setContent(iso)
 
         AbstractFilePathTestCase.setUp(self)

--- a/bp/tests/test_memory.py
+++ b/bp/tests/test_memory.py
@@ -56,7 +56,10 @@ class MemoryPathTestCase(AbstractFilePathTestCase):
 
         foo = self.path.child("foo")
         foo.setContent("Hi!")
-        baz = self.path.descendant(["bar", "baz"])
+
+        bar = self.path.child("bar")
+        bar.createDirectory()
+        baz = bar.child("baz")
         baz.setContent("Bye!")
 
         self.path.remove()

--- a/bp/tests/test_memory.py
+++ b/bp/tests/test_memory.py
@@ -11,6 +11,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from bp.errors import PathError
 from bp.memory import MemoryFS, MemoryPath, format_memory_path
 from bp.tests.test_paths import AbstractFilePathTestCase
 
@@ -81,5 +82,5 @@ class MemoryPathTestCase(AbstractFilePathTestCase):
         path = self.path.child("file")
         self.assertFalse(path.exists())
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(PathError):
             path.remove()

--- a/bp/tests/test_memory.py
+++ b/bp/tests/test_memory.py
@@ -41,3 +41,38 @@ class MemoryPathTestCase(AbstractFilePathTestCase):
         self.root = self.path
         self.all = self.fs._dirs | set(self.fs._store.keys())
         self.all = set(format_memory_path(p, "/") for p in self.all)
+
+    def test_removeDirectory(self):
+        """
+        L{MemoryPath.remove} on a L{MemoryPath} that refers to a
+        directory will recursively delete its contents.
+        """
+        self.assertTrue(self.path.isdir())
+        self.assertTrue(self.path.exists())
+
+        self.path.remove()
+        self.assertFalse(self.path.exists())
+
+    def test_removeFile(self):
+        """
+        L{MemoryPath.remove} on a L{MemoryPath} that refers to a
+        file simply deletes the file.
+        """
+        path = self.path.child("file")
+        path.setContent("Hello!")
+        self.assertTrue(path.isfile())
+        self.assertTrue(path.exists())
+
+        path.remove()
+        self.assertFalse(path.exists())
+
+    def test_removeNonExistant(self):
+        """
+        L{MemoryPath.remove} on a L{MemoryPath} that does not exist
+        raises an error.
+        """
+        path = self.path.child("file")
+        self.assertFalse(path.exists())
+
+        with self.assertRaises(Exception):
+            path.remove()

--- a/bp/tests/test_memory.py
+++ b/bp/tests/test_memory.py
@@ -40,7 +40,7 @@ class MemoryPathTestCase(AbstractFilePathTestCase):
 
         AbstractFilePathTestCase.setUp(self)
 
-        self.path = MemoryPath(self.fs)
+        self.path = MemoryPath(fs=self.fs)
         self.root = self.path
         self.all = self.fs._dirs | set(self.fs._store.keys())
         self.all = set(format_memory_path(p, "/") for p in self.all)

--- a/bp/tests/test_memory.py
+++ b/bp/tests/test_memory.py
@@ -11,6 +11,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import errno
+
 from bp.errors import PathError
 from bp.memory import MemoryFS, MemoryPath, format_memory_path
 from bp.tests.test_paths import AbstractFilePathTestCase
@@ -82,5 +84,6 @@ class MemoryPathTestCase(AbstractFilePathTestCase):
         path = self.path.child("file")
         self.assertFalse(path.exists())
 
-        with self.assertRaises(PathError):
+        with self.assertRaises(PathError) as e:
             path.remove()
+        self.assertEqual(e.exception.errno, errno.ENOENT)

--- a/bp/tests/test_memory.py
+++ b/bp/tests/test_memory.py
@@ -50,8 +50,13 @@ class MemoryPathTestCase(AbstractFilePathTestCase):
         self.assertTrue(self.path.isdir())
         self.assertTrue(self.path.exists())
 
+        foo = self.path.child("foo")
+        baz = self.path.descendant(["bar", "baz"])
+
         self.path.remove()
         self.assertFalse(self.path.exists())
+        self.assertFalse(foo.exists())
+        self.assertFalse(baz.exists())
 
     def test_removeFile(self):
         """

--- a/bp/tests/test_memory.py
+++ b/bp/tests/test_memory.py
@@ -51,7 +51,9 @@ class MemoryPathTestCase(AbstractFilePathTestCase):
         self.assertTrue(self.path.exists())
 
         foo = self.path.child("foo")
+        foo.setContent("Hi!")
         baz = self.path.descendant(["bar", "baz"])
+        baz.setContent("Bye!")
 
         self.path.remove()
         self.assertFalse(self.path.exists())

--- a/bp/tests/test_memory.py
+++ b/bp/tests/test_memory.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import errno
+import os
 
 from bp.errors import PathError
 from bp.memory import MemoryFS, MemoryPath, format_memory_path
@@ -87,3 +88,16 @@ class MemoryPathTestCase(AbstractFilePathTestCase):
         with self.assertRaises(PathError) as e:
             path.remove()
         self.assertEqual(e.exception.errno, errno.ENOENT)
+
+    def test_getUserID(self):
+        """
+        L{MemoryPath.getUserID} on a L{MemoryPath} returns the current user's
+        ID by default.
+
+        """
+
+        self.assertEqual(self.path.getUserID(), os.getuid())
+
+    def test_getUserID_after_set(self):
+        self.fs.chown(self.path, uid=1234, gid=-1)
+        self.assertEqual(self.path.getUserID(), 1234)

--- a/bp/tests/test_paths.py
+++ b/bp/tests/test_paths.py
@@ -112,6 +112,13 @@ class AbstractFilePathTestCase(BytesTestCase):
             self.path.child(b"a").child(b"b").child(b"c").segmentsFrom,
             self.path.child(b"d").child(b"c").child(b"e"))
 
+    def test_setContentNonExistingDirectory(self):
+        nonexistent = self.path.descendant([b'nonexistent', b'file'])
+        e = self.assertRaises(
+            (OSError, IOError), nonexistent.setContent, b'stuff',
+        )
+        self.assertEqual(e.errno, errno.ENOENT)
+
     def test_walk(self):
         """
         Verify that walking the path gives the same result as the known file

--- a/bp/zippath.py
+++ b/bp/zippath.py
@@ -130,6 +130,9 @@ class ZipPath(object):
     def setContent(self, content, ext=b'.new'):
         self.archive.zipfile.writestr(self.pathInArchive, content)
 
+    def remove(self):
+        raise Exception("Zip files do not support in-place removal.")
+
     # IFilePath stat and other queries
 
     def exists(self):

--- a/bp/zippath.py
+++ b/bp/zippath.py
@@ -29,7 +29,7 @@ from zipfile import ZipFile
 from zope.interface import implementer
 
 from bp.abstract import IFilePath
-from bp.errors import UnlistableError
+from bp.errors import PathError, UnlistableError
 from bp.filepath import FilePath
 from bp.generic import (genericChildren, genericDescendant, genericParents,
                         genericSegmentsFrom, genericSibling, genericWalk)
@@ -131,7 +131,7 @@ class ZipPath(object):
         self.archive.zipfile.writestr(self.pathInArchive, content)
 
     def remove(self):
-        raise Exception("Zip files do not support in-place removal.")
+        raise PathError("Zip files do not support in-place removal.")
 
     # IFilePath stat and other queries
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+characteristic
 vcversioner
 zope.interface>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-characteristic
+attrs
 vcversioner
 zope.interface>=4.0.0


### PR DESCRIPTION
Adds `remove` to `IFilePath`. I think as we discussed once it might be nice to have `IReadOnlyFilePath` and `IRemovableFilePath` at some point but this seems minimal work at the moment.

Most of the other paths here can't support some existing things already.

Lemme know what you think :)
